### PR TITLE
Add support for array styles

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -8,8 +8,9 @@
 "use strict";
 
 class Placeholder {
-    constructor(param, option = '', precision = 2, _default = null) {
+    constructor(param, arraystyle, option = '', precision = 2, _default = null) {
         this.param = param;
+        this.arraystyle = arraystyle;
         this.option = option;
         this.precision = precision;
         this.default = _default;

--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -60,7 +60,7 @@ class Formatter {
 
     formatValue(value, chunk) {
         if (Array.isArray(value))
-            return this.listToString(value.map((v) => this.formatValue(v, chunk)));
+            return this.listToString(value.map((v) => this.formatValue(v, chunk)), { type: chunk.arraystyle });
 
         switch (chunk.option) {
         case '':
@@ -107,11 +107,22 @@ class Formatter {
             return array.join(', ');
 
         if (!Intl.ListFormat) {
-            // emulate ListFormat for node 10
-            if (array.length === 2)
-                return array.join(' and ');
-            else
-                return array.slice(0, array.length-1).join(', ') + ', and ' + array[array.length-1];
+            if (this._locale.startsWith('en-')) {
+                // emulate ListFormat for node 10
+                if (options.type === 'disjunction') {
+                    if (array.length === 2)
+                        return array.join(' or ');
+                    else
+                        return array.slice(0, array.length-1).join(', ') + ', or ' + array[array.length-1];
+                } else {
+                    if (array.length === 2)
+                        return array.join(' and ');
+                    else
+                        return array.slice(0, array.length-1).join(', ') + ', and ' + array[array.length-1];
+                }
+            } else {
+                return array.join(', ');
+            }
         }
         return new Intl.ListFormat(this._locale, options).format(array);
     }

--- a/lib/grammar.pegjs
+++ b/lib/grammar.pegjs
@@ -69,11 +69,11 @@ select_variant = __ type:identifier __ '{' expansion:pattern_no_brace '}' __ {
     return [type, expansion];
 }
 
-wrapped_param = '${' __ param:qualified_name __ opt:option_clause? __ _default:(':-' pattern_no_brace)? '}' {
+wrapped_param = '${' __ param:qualified_name __ array_opt:(':' __ ('conjunction' / 'disjunction') __)? opt:option_clause? __ _default:(':-' pattern_no_brace)? '}' {
     if (opt)
-        return new Placeholder(param, ...opt, _default ? _default[1] : null);
+        return new Placeholder(param, array_opt ? array_opt[2] : undefined, ...opt, _default ? _default[1] : null);
     else
-        return new Placeholder(param, undefined, undefined, _default ? _default[1] : null);
+        return new Placeholder(param, array_opt ? array_opt[2] : undefined, undefined, undefined, _default ? _default[1] : null);
 }
 
 option_clause = ':' __ opt:option? '.' precision:integer_literal {

--- a/test.js
+++ b/test.js
@@ -46,9 +46,9 @@ function testChunks() {
 
     assert.deepStrictEqual(Array.from(interp.parse('foo $v ${v2:lol}')), [
         'foo ',
-        new interp.Placeholder('v', ''),
+        new interp.Placeholder('v', undefined, ''),
         ' ',
-        new interp.Placeholder('v2', 'lol', 1)
+        new interp.Placeholder('v2', undefined, 'lol', 1)
     ]);
 }
 
@@ -118,6 +118,13 @@ function testFormatValueLocalized() {
         v3: [date, date2],
         v4: [0.42, 0.84],
     }, options), 'lol, foo, and cat; 69.8 and 107.6; 5/23/2018, 9:18:00 PM and 1/7/2019, 10:30:00 AM; 2018-05-24T04:18:00.000Z and 2019-01-07T18:30:00.000Z; 42 and 84');
+
+    assert.deepStrictEqual(interp('${v1:conjunction}; ${v2:conjunction:F}; ${v3:disjunction}; ${v3:disjunction:iso-date}; ${v4:disjunction:%}', {
+        v1: ['lol', 'foo', 'cat'],
+        v2: [21, 42],
+        v3: [date, date2],
+        v4: [0.42, 0.84, 0.85],
+    }, options), 'lol, foo, and cat; 69.8 and 107.6; 5/23/2018, 9:18:00 PM or 1/7/2019, 10:30:00 AM; 2018-05-24T04:18:00.000Z or 2019-01-07T18:30:00.000Z; 42, 84, or 85');
 }
 
 function testFormatValueNonLocalized() {


### PR DESCRIPTION
ThingTalk is already using them through listToString, but unless
we have actual support (with tests) we'll get subtle bugs between
node 10 and node 12. So let's clean that up.